### PR TITLE
Updated classpath to use jars in lib folder

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,14 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="lib" path="C:/Users/User/Desktop/Programming/Java libs/joml-1.9.10.jar"/>
-	<classpathentry kind="lib" path="C:/Users/User/Desktop/Programming/Java Collab Workspace/LRR-remake/lib/slick-util3.jar"/>
-	<classpathentry kind="lib" path="C:/Users/User/Desktop/Programming/Java libs/lwjgl 3.0.0/jar/lwjgl.jar">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
-			<attribute name="org.eclipse.jdt.launching.CLASSPATH_ATTR_LIBRARY_PATH_ENTRY" value="C:/Users/USER/Desktop/Programming/Java libs/lwjgl 3.0.0/native"/>
+			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/Users/User/Desktop/Programming/Java Collab Workspace/LRR-remake/lib/luaj-jse-3.0.1.jar"/>
+	<classpathentry kind="lib" path="lib/joml-1.9.10.jar"/>
+	<classpathentry kind="lib" path="lib/luaj-jse-3.0.1.jar"/>
+	<classpathentry kind="lib" path="lib/lwjgl 3.2.1/lwjgl.jar"/>
+	<classpathentry kind="lib" path="lib/lwjgl 3.2.1/lwjgl-natives-windows.jar"/>
+	<classpathentry kind="lib" path="lib/slick-util3.jar"/>
+	<classpathentry kind="lib" path="lib/lwjgl 3.2.1/lwjgl-glfw.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:platform:/resource/LRR-remake/lib/lwjgl%203.2.1/lwjgl-glfw-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib/lwjgl 3.2.1/lwjgl-glfw-natives-windows.jar"/>
+	<classpathentry kind="lib" path="lib/lwjgl 3.2.1/lwjgl-opengl.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:platform:/resource/LRR-remake/lib/lwjgl%203.2.1/lwjgl-opengl-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib/lwjgl 3.2.1/lwjgl-opengl-natives-windows.jar"/>
+	<classpathentry kind="lib" path="lib/lwjgl 3.2.1/lwjgl-openal.jar">
+		<attributes>
+			<attribute name="javadoc_location" value="jar:platform:/resource/LRR-remake/lib/lwjgl%203.2.1/lwjgl-openal-javadoc.jar!/"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib/lwjgl 3.2.1/lwjgl-openal-natives-windows.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
Changed the classpath to use the jars in the lib folder. This lets other people download the project without the build path breaking.